### PR TITLE
Rename package to eu.*

### DIFF
--- a/grpc.proto
+++ b/grpc.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package pl.ostrzyciel.jelly.core.proto;
+package eu.ostrzyciel.jelly.core.proto;
 
 // gRPC service specifications for RDF streaming.
 

--- a/rdf.proto
+++ b/rdf.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package pl.ostrzyciel.jelly.core.proto;
+package eu.ostrzyciel.jelly.core.proto;
 
 // Protocol Buffers Rdf serialization.
 


### PR DESCRIPTION
I happen to also own ostrzyciel.eu, so... seems a bit better.