### PR TITLE
Add a space before dot in test cases for Titanium parsers

### DIFF
--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_001/in_000.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_001/in_000.nq
@@ -1,3 +1,3 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
-<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/C> <http://example.org/graph/G>.
-<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/D> _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/C> <http://example.org/graph/G> .
+<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/D> _:bn1 .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_002/in_000.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_002/in_000.nq
@@ -1,5 +1,5 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
-<http://example.org/resource/A> <http://example.org/property/p> "Literal with langtag"@en _:bn1.
-<http://example.org/resource/B> <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
-<http://example.org/resource/C> <http://example.org/property/p> _:bn3 <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
+<http://example.org/resource/A> <http://example.org/property/p> "Literal with langtag"@en _:bn1 .
+<http://example.org/resource/B> <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
+<http://example.org/resource/C> <http://example.org/property/p> _:bn3 <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_003/in_000.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_003/in_000.nq
@@ -2,10 +2,10 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
 
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1.
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1.
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1 .
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1 .
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1 .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_000.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_000.nq
@@ -1,7 +1,7 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
 
-<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G>.
+<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G> .
 
-<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1 .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_001.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_001.nq
@@ -1,6 +1,6 @@
-<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1 .
 
-<http://example.org/resource/F> <http://example.org/property/p2> _:bn2 _:bn1.
+<http://example.org/resource/F> <http://example.org/property/p2> _:bn2 _:bn1 .
 
 <http://example.org/resource/C> <http://example.org/property/p1> <http://example.org/resource/A> .
 
@@ -10,4 +10,4 @@
 
 <http://example.org/resource/C> <http://example.org/property/p1> <http://example.org/resource/A> <http://example.org/graph/G1> .
 
-<http://example.org/resource/F> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G1>.
+<http://example.org/resource/F> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G1> .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_002.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_004/in_002.nq
@@ -4,4 +4,4 @@
 
 <http://example.org/resource/E> <http://example.org/property/p1> <http://example.org/resource/F> .
 
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G>.
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_000.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_000.nq
@@ -1,5 +1,5 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
 
-<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G>.
+<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_001.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_001.nq
@@ -1,8 +1,8 @@
-<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G>.
+<http://example.org/resource/C> <http://example.org/property/p> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> <http://example.org/graph/G> .
 
-<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1 .
 
-<http://example.org/resource_ext/F> <http://example.org/property/p2> _:bn2 _:bn1.
+<http://example.org/resource_ext/F> <http://example.org/property/p2> _:bn2 _:bn1 .
 
 <http://example.org/resource/B> <http://example.org/property/p> <http://example.org/resource/H> .
 

--- a/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_002.nq
+++ b/test/rdf/to_jelly/graphs_rdf_1_1/pos_005/in_002.nq
@@ -4,4 +4,4 @@
 
 <http://example.org/resource_ext/F> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G>.
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_001/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_001/in_000.nq
@@ -1,3 +1,3 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
-<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/C> <http://example.org/graph/G>.
+<http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/C> <http://example.org/graph/G> .
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/D> _:bn1 .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_002/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_002/in_000.nq
@@ -1,5 +1,5 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
-<http://example.org/resource/A> <http://example.org/property/p> "Literal with langtag"@en _:bn1.
-<http://example.org/resource/B> <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
-<http://example.org/resource/C> <http://example.org/property/p> _:bn3 <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
+<http://example.org/resource/A> <http://example.org/property/p> "Literal with langtag"@en _:bn1 .
+<http://example.org/resource/B> <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
+<http://example.org/resource/C> <http://example.org/property/p> _:bn3 <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_003/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_003/in_000.nq
@@ -1,8 +1,8 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
-_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
+_:bn2 <http://example.org/property/p> "Literal" <http://example.org/graph/G> .
 
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1 .
 <http://example.org/resource/A> <http://example.org/property/p> _:bn3 _:bn1 .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_000.nq
@@ -1,5 +1,5 @@
 <http://example.org/resource/A> <http://example.org/property/p> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
 
 <http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1 .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_001.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_001.nq
@@ -1,7 +1,7 @@
-<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p2> _:bn3 _:bn1 .
 
 <http://example.org/resource/E> <http://example.org/property/p1> <http://example.org/resource/F> .
 
 <http://example.org/resource/E> <http://example.org/property/p1> <http://example.org/resource/F> _:bn1 .
 
-<http://example.org/resource/H> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#float> <http://example.org/graph/G1>.
+<http://example.org/resource/H> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#float> <http://example.org/graph/G1> .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_002.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_004/in_002.nq
@@ -2,4 +2,4 @@
 
 <http://example.org/resource/E> <http://example.org/property/p1> <http://example.org/resource/F> .
 
-<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G>.
+<http://example.org/resource/A> <http://example.org/property/p> _:bn3 <http://example.org/graph/G> .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_005/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_005/in_000.nq
@@ -1,7 +1,7 @@
 <http://example.org/resource/A> <http://example.org/property/p1> <http://example.org/resource/B> .
 
-_:bn2 <http://example.org/property/p2> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p2> "100"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
 
-<http://example.org/resource/A> <http://example.org/property/p3> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p3> _:bn3 _:bn1 .
 
 <http://example.org/resource/A> <http://example.org/property/p3> _:bn3 _:bn1 .

--- a/test/rdf/to_jelly/quads_rdf_1_1/pos_005/in_001.nq
+++ b/test/rdf/to_jelly/quads_rdf_1_1/pos_005/in_001.nq
@@ -1,14 +1,14 @@
-<http://example.org/resource/A> <http://example.org/property/p3> _:bn3 _:bn1.
+<http://example.org/resource/A> <http://example.org/property/p3> _:bn3 _:bn1 .
 
 <http://example.org/resource/E> <http://example.org/property/p2> "0.01"^^<http://www.w3.org/2001/XMLSchema#float> .
 
 <http://example.org/resource/E> <http://example.org/property/p2> <http://example.org/resource/F> _:bn1 .
 
-<http://example.org/resource/H> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#float> <http://example.org/graph/G1>.
+<http://example.org/resource/H> <http://example.org/property/p2> "0.1"^^<http://www.w3.org/2001/XMLSchema#float> <http://example.org/graph/G1> .
 
-_:bn2 <http://example.org/property/p1> "200"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G>.
+_:bn2 <http://example.org/property/p1> "200"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G> .
 
-_:bn2 <http://example.org/property/p1> "200"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G1>.
+_:bn2 <http://example.org/property/p1> "200"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph/G1> .
 
 _:bn2 <http://example.org/property/p1> "200"^^<http://www.w3.org/2001/XMLSchema#integer> .
 

--- a/test/rdf/to_jelly/quads_rdf_star_generalized/pos_005/in_000.nq
+++ b/test/rdf/to_jelly/quads_rdf_star_generalized/pos_005/in_000.nq
@@ -7,7 +7,7 @@ _:bn_org "hasLinkTo" << _:bn_org1 "hasLinkTo" << _:bn_org2 "hasLinkTo" << _:bn_o
 _:bn_org3 "hasLinkTo" _:bn_org1 .
 <http://example.org/program/p1> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> .
 << << << <http://example.org/program/p1> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> .
-<< _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link _:anon_graph.
+<< _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link _:anon_graph .
 _:anonymous_person _:anonymous_link _:anonymous_person1 .
 _:anonymous_person _:anonymous_link _:anonymous_person1 _:anon_graph .
 << _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link "anonymous" _:anon_graph .

--- a/test/rdf/to_jelly/quads_rdf_star_generalized/pos_006/in_002.nq
+++ b/test/rdf/to_jelly/quads_rdf_star_generalized/pos_006/in_002.nq
@@ -5,7 +5,7 @@ _:bn_org "hasLinkTo" << _:bn_org1 "hasLinkTo" << _:bn_org2 "hasLinkTo" << _:bn_o
 _:bn_org3 "hasLinkTo" _:bn_org1 .
 <http://example.org/program/p1> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> .
 << << << <http://example.org/program/p1> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> >> "versioned" "0.1"^^<http://www.w3.org/2001/XMLSchema#float> .
-<< _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link _:anon_graph.
+<< _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link _:anon_graph .
 _:anonymous_person _:anonymous_link _:anonymous_person1 .
 _:anonymous_person _:anonymous_link _:anonymous_person1 _:anon_graph .
 << _:anonymous_person << _:anonymous_person _:anonymous_link _:anonymous_person1 >>  _:anonymous_person1 >> _:anonymous_link "anonymous" _:anon_graph .

--- a/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006/in_000.nt
+++ b/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006/in_000.nt
@@ -2,7 +2,7 @@
 << <http://example.org/resource/r1> <http://example.org/property/belongsTo> <http://example.org/organization/o1> >> <http://example.org/property/notedBy> <http://example.org/ministry/m1> .
 << _:bn_s_tt _:bn_p_tt _:bn_o_tt >> _:bn_property _:bn_obj .
 << "Resource" "locatedAt" "Place" >> "reportedBy" "Unknown Source" .
-<http://example.org/organization/o1> <http://example.org/action/talkedAbout> <http://example.org/project/p1>.
+<http://example.org/organization/o1> <http://example.org/action/talkedAbout> <http://example.org/project/p1> .
 <http://example.org/resource/r1> << _:bn_pr "Describes" _:bn_connection >> <http://example.org/organization/o2> .
 _:bn_subj << _:bn_s _:bn_p  _:bn_connection >> _:bn_obj .
 _:bn_subj << _:bn_s _:bn_p  _:bn_connection >> _:bn_obj .

--- a/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006/in_001.nt
+++ b/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006/in_001.nt
@@ -1,7 +1,7 @@
 _:bn_connection <http://example.org/property/isRequired> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 "1000"^^<http://www.w3.org/2001/XMLSchema#integer> << _:bn_s _:bn_p _:bn_connection >> "2021-11-12"^^<http://www.w3.org/2001/XMLSchema#date> .
 
-<http://example.org/ministry/m1> <http://example.org/property/hasImpact> "true"^^<http://www.w3.org/2001/XMLSchema#boolean>.
+<http://example.org/ministry/m1> <http://example.org/property/hasImpact> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.org/property/hasImpact> <http://example.org/property/allocatedTo> <http://example.org/organization/o> .
 <http://example.org/source/s1> <http://example.org/property/hasDescription> << "Source"@en "Reported By"@en "Person"@en >> .
 <http://example.org/source/s2> <http://example.org/property/hasDescription> << "Source"@en "Reported By"@en "Person"@en >> .


### PR DESCRIPTION
Continuation of #86 
Titanium NQ parser sometimes breaks if there isn't a whitespace separator before a dot. This PR adds a space for all instances of `[non-whitespace].[end line]`, which will also make the test cases more consistent.

Commands used:
```
find . -type f -name "*.nq" -exec sed -ri 's/([^ ])[.]$/\1 ./g' {} \;
find . -type f -name "*.nt" -exec sed -ri 's/([^ ])[.]$/\1 ./g' {} \;
```