### PR TITLE
Docs: Quick fix in the link 

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,4 +3,4 @@
 Machine-readable test manifests are in the `manifest.ttl` file of each subdirectory. The manifests follow the vocabulary in the `vocabulary.ttl` file.
 
 - `rdf` – tests for the [Jelly RDF serialization format specification](https://w3id.org/jelly/dev/specification/serialization/) (Jelly-RDF).
-- `grpc` – tests for the [Jelly gRPC streaming protocol specification](https://w3id.org/jelly/dev/specification/protocol/) (Jelly-RDF gRPC).
+- `grpc` – tests for the [Jelly gRPC streaming protocol specification](https://w3id.org/jelly/dev/specification/streaming/) (Jelly-RDF gRPC).


### PR DESCRIPTION
Fix the reference in the grpc in tests, which currently has the wrong reference.